### PR TITLE
Use updated GitHub pages docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .jekyll-metadata
 node_modules
 .idea/
+.sass-cache/

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
+set -o xtrace
 
 # get submodules (reveal.js)
 git submodule init
 git pull --recurse-submodules
 
-# run local jekyll server; will be served at localhost:4000
-export JEKYLL_VERSION=3.8
+# run local jekyll server; will be served at http://localhost:4000
+# latest version from https://github.com/github/pages-gem/releases
+export GITHUB_PAGES_GEM_VERSION=v232
 docker run --rm \
-  --volume="$PWD:/srv/jekyll" -p 4000:4000 \
+  --volume="$PWD:/src/site" -p 4000:4000 \
   --env JEKYLL_UID=$(id -u) --env JEKYLL_GID=$(id -g) \
-  -it jekyll/jekyll:$JEKYLL_VERSION \
-  jekyll serve --future --drafts
+  -it ghcr.io/github/pages-gem:$GITHUB_PAGES_GEM_VERSION \
+  jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling --incremental


### PR DESCRIPTION
Update `build.sh` to use the most compatible github pages docker image from https://github.com/github/pages-gem/releases so the local server matches production (dependencies: https://pages.github.com/versions/ ).


```sh
$ ./build.sh 
+ git submodule init
+ git pull --recurse-submodules
Fetching submodule reveal.js
Already up to date.
+ export GITHUB_PAGES_GEM_VERSION=v232
+ id -u
+ id -g
+ docker run --rm --volume=/home/lmagasweran/src/personal/berlinhackandtell.rocks:/src/site -p 4000:4000 --env JEKYLL_UID=10801 --env JEKYLL_GID=10801 -it ghcr.io/github/pages-gem:v232 jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling --incremental
Configuration file: /src/site/_config.yml
            Source: /src/site
       Destination: /src/site/_site
 Incremental build: enabled
      Generating... 
                    done in 0.191 seconds.
 Auto-regeneration: enabled for '/src/site'
    Server address: http://0.0.0.0:4000
  Server running... press ctrl-c to stop.
```
