### PR TITLE
Fix IOCCC link

### DIFF
--- a/_posts/2020-01-28-no77-hacking-2020.md
+++ b/_posts/2020-01-28-no77-hacking-2020.md
@@ -9,7 +9,7 @@ meetupUrl: https://www.meetup.com/de-DE/Berlin-Hack-and-Tell/events/268089955/
 
 * [Vote2p](https://github.com/gimlet2/vote2p) (voting, ipfs, pubsub) by [Andrey](https://github.com/gimlet2)
 * [FPGA Badge Hack](https://hackaday.io/page/6764-hackaday-supercon-badge-boots-linux-using-sdram-cartridge) - Linux on RISC-V by [Drew Fustini](https://github.com/pdp7)
-* [Obfuscated Compressor](https://www.ioccc.org/2019/diels-grabsch1/hint.html) by [Volker Diels-Grabsch](https://njh.eu/)
+* [Obfuscated Compressor](https://www.ioccc.org/2019/diels-grabsch1/index.html) by [Volker Diels-Grabsch](https://njh.eu/)
 * [Super Resolution HTTP API](https://github.com/momonala/supersizeme) by [Mohit Nalavadi](https://github.com/momonala)
 * doorbell monitor by [Jaseg](https://github.com/jaseg)
 * [sonic creatures: melodic harp circuit sculpture](https://www.youtube.com/watch?v=_8q6Gq_PAiE) by [Helen Leigh](https://www.youtube.com/user/helenlsteer) - **Hack of the month**


### PR DESCRIPTION
Fix the link to my IOCCC entry. The IOCCC website just had a relaunch and unfortunately some URLs changed.

<!-- 

_Please check links by adding the [needs-url-checks](https://github.com/berlin-hack-and-tell/berlinhackandtell.rocks/labels/needs-url-checks) label to your PR._

-->
